### PR TITLE
fixed "store" object is not extensible

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = class MongooseTrailpack extends DatastoreTrailpack {
     this.models = lib.Transformer.transformModels(this.app)
 
     this.orm = this.orm || {};
-    this.connections = _.mapValues(this.app.config.database.stores, (store, storeName) => {
+    this.connections = _.mapValues(this.app.config.database.stores, (_store, storeName) => {
+      let store = _.merge({}, _store)
       if (!_.isString(store.uri))
         throw new Error('Store have to contain "uri" option')
 


### PR DESCRIPTION
Looks like the object stored in database.js is by default not extensible and this will throw an error when trying to add properties. I'm using node v6, maybe because of that?
