### PR TITLE
Define Schema so that the example actually works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ module.exports = {
 ### Models
 
 ```js
+// Use default Schema from Mongoose. See http://mongoosejs.com/docs/schematypes.html
+const Schema = require('mongoose').Schema;
+
 module.exports = class User extends Model {
 
   static schema () {


### PR DESCRIPTION
This removes a potential stumbling block in the example, as reported in #9.

The example uses `Schema` as a variable but never defines it.
