### PR TITLE
- Transformer call config & schema with app & Mongoose reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,13 @@ module.exports = {
 
 ```js
 // Use default Schema from Mongoose. See http://mongoosejs.com/docs/schematypes.html
-const Schema = require('mongoose').Schema;
-
 module.exports = class User extends Model {
 
-  static schema () {
+  static schema (app, Mongoose) {
     return {
       username: String,
       childs: [{
-        type: Schema.ObjectId,
+        type: Mongoose.Schema.ObjectId,
         ref: 'UserSchema'
       }],
       email: {
@@ -105,7 +103,7 @@ module.exports = class User extends Model {
     }
   }
 
-  static config () {
+  static config (app, Mongoose) {
     return {
       // Collection name
       tableName: 'users',

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -24,8 +24,8 @@ module.exports = {
     const models = app.models
     const dbConfig = app.config.database
     return _.mapValues(models, (model, modelName) => {
-      const config = model.constructor.config() || { }
-      const schema = model.constructor.schema() || { }
+      const config = model.constructor.config(app, require('mongoose')) || { }
+      const schema = model.constructor.schema(app, require('mongoose')) || { }
       const onSchema = model.constructor.onSchema || _.noop
 
       return {


### PR DESCRIPTION
Transformer will inject app & mongoose references while calling `config()` and `schema()`
I think that it's more similar to how other trailpacks-databases handle Model configuration and we need it for `trailpack-passport`
