### PR TITLE
- Association population test

### DIFF
--- a/test/services/FootprintService.test.js
+++ b/test/services/FootprintService.test.js
@@ -179,6 +179,45 @@ describe('api.services.FootprintService', () => {
           assert.equal(rec.roles[0], role.id)
         })
     })
+
+    it('should create an assotiation record and populate it', () => {
+      return FootprintService
+        .createAssociation('User', user._id, 'role', { name: 'test' }) // eslint-disable-line
+        .then((rec) => {
+          assert(rec)
+          assert(rec._id) // eslint-disable-line
+          assert.equal(rec.name, 'test')
+
+          role = rec
+          return FootprintService
+            .find('User', user._id,{populate:"role"}) // eslint-disable-line
+        })
+        .then((rec) => {
+          assert(rec)
+          assert.equal(rec.id, user.id) // eslint-disable-line
+          assert.equal(rec.role.id, role.id)
+          assert.equal(rec.role.name, role.name)
+        })
+    })
+
+    it('should add record into array and populate it', () => {
+      return FootprintService
+        .createAssociation('User', user.id, 'roles', { name: 'temp' })
+        .then((rec) => {
+          assert(rec)
+          role = rec
+          return FootprintService
+            .find('User', user.id, { findOne: true, populate: 'roles' })
+        })
+        .then((rec) => {
+          assert(rec)
+          assert.equal(rec.id, user.id)
+          assert(_.isArray(rec.roles))
+          assert.equal(rec.roles.length, 1)
+          assert.equal(rec.roles[0].id, role.id)
+          assert.equal(rec.roles[0].name, role.name)
+        })
+    })
   })
 
   describe('#findAssociation', () => {


### PR DESCRIPTION
Actually association test pass because we check if the model has an ObjectId (or array of ObjectId) and it's true

Unfortunately, I'm having some problems with field population
If we try to populate fields we expect to have a Role instance instead of an ObjectId but the test fail, the trailpack seems to don't populate the field

Can you help me about this?
