### PR TITLE
Fix hardcoded parent model name on findAssociation

### DIFF
--- a/api/services/FootprintService.js
+++ b/api/services/FootprintService.js
@@ -304,7 +304,7 @@ module.exports = class FootprintService extends Service {
 
     options = options || {}
     return this
-      .find('User', parentId, options)
+      .find(parentModelName, parentId, options)
       .then((record) => {
         if (!record)
           return Promise.reject(new Error('No parent record found'))


### PR DESCRIPTION
The parent model name, when querying in findAssociation is hardcoded as 'User', this commit changes the value for the one passed in the function.